### PR TITLE
Add Bootstrap 5 support

### DIFF
--- a/lib/simple_navigation_bootstrap.rb
+++ b/lib/simple_navigation_bootstrap.rb
@@ -18,3 +18,4 @@ end
 SimpleNavigation.register_renderer(bootstrap2: SimpleNavigationBootstrap::Bootstrap2)
 SimpleNavigation.register_renderer(bootstrap3: SimpleNavigationBootstrap::Bootstrap3)
 SimpleNavigation.register_renderer(bootstrap4: SimpleNavigationBootstrap::Bootstrap4)
+SimpleNavigation.register_renderer(bootstrap5: SimpleNavigationBootstrap::Bootstrap5)

--- a/lib/simple_navigation_bootstrap/bootstrap5.rb
+++ b/lib/simple_navigation_bootstrap/bootstrap5.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module SimpleNavigationBootstrap
+  class Bootstrap5 < SimpleNavigation::Renderer::Base
+
+    include BootstrapBase
+
+
+    private
+
+
+      def bootstrap_version
+        5
+      end
+
+
+      def navigation_class
+        'navbar-nav'
+      end
+
+
+      # def container_class(_level)
+      #   remove_navigation_class = options.fetch(:remove_navigation_class, false)
+      #   remove_navigation_class ? '' : ['nav', navigation_class].compact
+      # end
+
+  end
+end

--- a/lib/simple_navigation_bootstrap/bootstrap5.rb
+++ b/lib/simple_navigation_bootstrap/bootstrap5.rb
@@ -19,10 +19,9 @@ module SimpleNavigationBootstrap
       end
 
 
-      # def container_class(_level)
-      #   remove_navigation_class = options.fetch(:remove_navigation_class, false)
-      #   remove_navigation_class ? '' : ['nav', navigation_class].compact
-      # end
+      def render_item(*)
+        SimpleNavigationBootstrap::RenderedItem5.new(*).to_s
+      end
 
   end
 end

--- a/lib/simple_navigation_bootstrap/rendered_item.rb
+++ b/lib/simple_navigation_bootstrap/rendered_item.rb
@@ -98,7 +98,7 @@ module SimpleNavigationBootstrap
 
 
       def dropdown_part(name) # rubocop:disable Metrics/AbcSize
-        options[:class] = [options[:class], 'dropdown'].flatten.compact.join(' ')
+        options[:class] = [options[:class], 'dropdown-menu'].flatten.compact.join(' ')
         link_options[:class] = [link_options[:class], 'dropdown-toggle'].flatten.compact.join(' ')
         link_options[:'data-toggle'] = 'dropdown'
         link_options[:'data-target'] = '#'

--- a/lib/simple_navigation_bootstrap/rendered_item.rb
+++ b/lib/simple_navigation_bootstrap/rendered_item.rb
@@ -98,7 +98,7 @@ module SimpleNavigationBootstrap
 
 
       def dropdown_part(name) # rubocop:disable Metrics/AbcSize
-        options[:class] = [options[:class], 'dropdown-menu'].flatten.compact.join(' ')
+        options[:class] = [options[:class], 'dropdown'].flatten.compact.join(' ')
         link_options[:class] = [link_options[:class], 'dropdown-toggle'].flatten.compact.join(' ')
         link_options[:'data-toggle'] = 'dropdown'
         link_options[:'data-target'] = '#'

--- a/lib/simple_navigation_bootstrap/rendered_item5.rb
+++ b/lib/simple_navigation_bootstrap/rendered_item5.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module SimpleNavigationBootstrap
+  class RenderedItem5 < RenderedItem
+    private
+
+    def li_link # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      if include_sub_navigation?(item)
+        if level == 1
+          if split
+            splitted_simple_part + splitted_dropdown_part
+          else
+            content = [item.name]
+            content << caret unless skip_caret
+            content = content.join(" ").html_safe
+            dropdown_part(content)
+          end
+        else
+          content_tag(:li, dropdown_submenu_link, options)
+        end
+      else
+        options[:class] = [options[:class], "nav-item"].flatten.compact.join(
+          " "
+        ) if level == 1
+        content_tag(:li, simple_link, options)
+      end
+    end
+
+    def dropdown_part(name) # rubocop:disable Metrics/AbcSize
+      options[:class] = [options[:class], "nav-item", "dropdown"].flatten
+        .compact
+        .join(" ")
+      link_options[:class] = [
+        link_options[:class],
+        "nav-link",
+        "dropdown-toggle"
+      ].flatten.compact.join(" ")
+      link_options[:"role"] = "button"
+      link_options[:"data-bs-toggle"] = "dropdown"
+      link_options[:"aria-expanded"] = "false"
+
+      content =
+        link_to(name, "#", link_options) + render_sub_navigation_for(item)
+      content_tag(:li, content, options)
+    end
+
+    def simple_link
+      link_class = level == 1 ? "nav-link" : "dropdown-item"
+      link_options[:class] = [options[:class], link_class].flatten.compact.join(" ")
+      link_options[:method] ||= item.method
+      url = item.url || "#"
+      link_to(item.name, url, link_options)
+    end
+  end
+end

--- a/lib/simple_navigation_bootstrap/rendered_item5.rb
+++ b/lib/simple_navigation_bootstrap/rendered_item5.rb
@@ -46,8 +46,9 @@ module SimpleNavigationBootstrap
 
     def simple_link
       link_class = level == 1 ? "nav-link" : "dropdown-item"
-      link_options[:class] = [link_options[:class], link_class].flatten.compact.join(" ")
+      link_options[:class] = [link_options[:class], link_class, item.selected_class].flatten.compact.join(" ")
       link_options[:method] ||= item.method
+      link_options[:"aria-current"] = "page" if item.selected?
       url = item.url || "#"
       link_to(item.name, url, link_options)
     end

--- a/lib/simple_navigation_bootstrap/rendered_item5.rb
+++ b/lib/simple_navigation_bootstrap/rendered_item5.rb
@@ -46,7 +46,7 @@ module SimpleNavigationBootstrap
 
     def simple_link
       link_class = level == 1 ? "nav-link" : "dropdown-item"
-      link_options[:class] = link_class
+      link_options[:class] = [link_options[:class], link_class].flatten.compact.join(" ")
       link_options[:method] ||= item.method
       url = item.url || "#"
       link_to(item.name, url, link_options)

--- a/lib/simple_navigation_bootstrap/rendered_item5.rb
+++ b/lib/simple_navigation_bootstrap/rendered_item5.rb
@@ -35,7 +35,7 @@ module SimpleNavigationBootstrap
         "nav-link",
         "dropdown-toggle"
       ].flatten.compact.join(" ")
-      link_options[:"role"] = "button"
+      link_options[:role] = "button"
       link_options[:"data-bs-toggle"] = "dropdown"
       link_options[:"aria-expanded"] = "false"
 
@@ -46,7 +46,7 @@ module SimpleNavigationBootstrap
 
     def simple_link
       link_class = level == 1 ? "nav-link" : "dropdown-item"
-      link_options[:class] = [options[:class], link_class].flatten.compact.join(" ")
+      link_options[:class] = link_class
       link_options[:method] ||= item.method
       url = item.url || "#"
       link_to(item.name, url, link_options)

--- a/spec/lib/simple_navigation_bootstrap_spec.rb
+++ b/spec/lib/simple_navigation_bootstrap_spec.rb
@@ -14,4 +14,8 @@ RSpec.describe SimpleNavigationBootstrap do
   it 'registers Bootstrap4 renderer' do
     expect(SimpleNavigation.registered_renderers[:bootstrap4]).to eq SimpleNavigationBootstrap::Bootstrap4
   end
+
+  it 'registers Bootstrap5 renderer' do
+    expect(SimpleNavigation.registered_renderers[:bootstrap5]).to eq SimpleNavigationBootstrap::Bootstrap5
+  end
 end


### PR DESCRIPTION
Initial Bootstrap 5 support. Should work for level 1 navigation with dropdown menus with one level. More levels, separators and other special cases need to be tested.